### PR TITLE
Fix indentation, add example

### DIFF
--- a/UKB_notebooks/ukb-rap-pheno-basic.ipynb
+++ b/UKB_notebooks/ukb-rap-pheno-basic.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# UK Biobank Research Analysis Platform - Basic data extraction\n",
     "\n",
-    "(_Disclaimer: This notebook is delivered \"As-Is\". Notwithstanding anything to the contrary, DNAnexus will have no warranty, support, liability or other obligations with respect to Materials provided hereunder. The [MIT License](https://github.com/dnanexus/OpenBio/blob/master/LICENSE.md) applies to this notebook._)"
+    "(_Disclaimer: This notebook is delivered 'As-Is'. Notwithstanding anything to the contrary, DNAnexus will have no warranty, support, liability or other obligations with respect to Materials provided hereunder. The [MIT License](https://github.com/dnanexus/OpenBio/blob/master/LICENSE.md) applies to this notebook._)"
    ]
   },
   {
@@ -41,6 +41,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "dxdata.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Spark initialization (Done only once; do not rerun this cell unless you select Kernel -> Restart kernel).\n",
     "sc = pyspark.SparkContext()\n",
     "spark = pyspark.sql.SparkSession(sc)"
@@ -54,19 +63,19 @@
    "source": [
     "# Automatically discover dispensed database name and dataset id\n",
     "dispensed_database = dxpy.find_one_data_object(\n",
-    "    classname=\"database\", \n",
-    "    name=\"app*\", \n",
-    "    folder=\"/\", \n",
-    "    name_mode=\"glob\", \n",
+    "    classname='database', \n",
+    "    name='app*', \n",
+    "    folder='/', \n",
+    "    name_mode='glob', \n",
     "    describe=True)\n",
-    "dispensed_database_name = dispensed_database[\"describe\"][\"name\"]\n",
+    "dispensed_database_name = dispensed_database['describe']['name']\n",
     "\n",
     "dispensed_dataset = dxpy.find_one_data_object(\n",
-    "    typename=\"Dataset\", \n",
-    "    name=\"app*.dataset\", \n",
-    "    folder=\"/\", \n",
-    "    name_mode=\"glob\")\n",
-    "dispensed_dataset_id = dispensed_dataset[\"id\"]"
+    "    typename='Dataset', \n",
+    "    name='app*.dataset', \n",
+    "    folder='/', \n",
+    "    name_mode='glob')\n",
+    "dispensed_dataset_id = dispensed_dataset['id']"
    ]
   },
   {
@@ -89,10 +98,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dataset \"entities\" are virtual tables linked to one another.\n",
+    "### Dataset 'entities' are virtual tables linked to one another.\n",
     "\n",
-    "The main entity is \"participant\" and corresponds to most pheno fields. Additional entities correspond to linked health care data.\n",
-    "Entities starting with \"hesin\" are for hospital records; entities starting with \"gp\" are for GP records, etc."
+    "The main entity is 'participant' and corresponds to most pheno fields. Additional entities correspond to linked health care data.\n",
+    "Entities starting with 'hesin' are for hospital records; entities starting with 'gp' are for GP records, etc."
    ]
   },
   {
@@ -117,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "participant = dataset[\"participant\"]"
+    "participant = dataset['participant']"
    ]
   },
   {
@@ -146,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "field_names = [\"eid\", \"p31\", \"p21022\", \"p40005_i0\", \"p93_i0_a0\"]"
+    "field_names = ['eid', 'p31', 'p21022', 'p40005_i0', 'p93_i0_a0']"
    ]
   },
   {
@@ -192,7 +201,7 @@
    "outputs": [],
    "source": [
     "# Participant sex\n",
-    "field_names_for_id(\"31\")"
+    "field_names_for_id('31')"
    ]
   },
   {
@@ -202,7 +211,7 @@
    "outputs": [],
    "source": [
     "# Age when attending assessment centre has multiple instances (visits) \n",
-    "field_names_for_id(\"21003\")"
+    "field_names_for_id('21003')"
    ]
   },
   {
@@ -212,7 +221,25 @@
    "outputs": [],
    "source": [
     "# Pulse rate has multiple instances and array indices (measured twice in each visit)\n",
-    "field_names_for_id(\"102\")"
+    "field_names_for_id('102')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Obtain field name for all instances and arrays for each field_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "field_ids = ['21003', '102']\n",
+    "# sum flattens list of lists\n",
+    "sum([field_names_for_id(field_id) for field_id in field_ids], []) "
    ]
   },
   {
@@ -279,9 +306,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "field_names = [\"eid\", \"p31\", \"p21022\"] \n",
-    "    + field_names_for_id(\"41262\") \n",
-    "    + field_names_by_title_keyword('diagnoses - main')"
+    "field_names = ['eid', 'p31', 'p21022'] \\\n",
+    "    + field_names_for_id('41262') \\\n",
+    "    + field_names_by_title_keyword('standing height')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "field_names"
    ]
   },
   {
@@ -292,7 +328,7 @@
     "\n",
     "The `participant.retrieve_fields` function can be used to construct a Spark DataFrame of the given fields.\n",
     "\n",
-    "By default, this retrieves data as encoded by UK Biobank. For example, field p31 (participant sex) will be returned as an integer column with values of 0 and 1. To receive decoded values, supply the `coding_values=\"replace\"` argument.\n",
+    "By default, this retrieves data as encoded by UK Biobank. For example, field p31 (participant sex) will be returned as an integer column with values of 0 and 1. To receive decoded values, supply the `coding_values='replace'` argument.\n",
     "\n",
     "For more information, see [Tips for Retrieving Fields](https://dnanexus.gitbook.io/uk-biobank-rap/getting-started/working-with-ukb-data#tips-for-retrieving-fields) in the documentation."
    ]
@@ -337,7 +373,7 @@
     "The expression can be either :\n",
     "\n",
     "* a string expression, built using SQL field names (e.g. `p31`) and SQL operators (e.g. `=`, `NOT`, `OR`, `AND`)\n",
-    "  * example: `\"(p21022 >= 50) AND (p31 = 0)\"`\n",
+    "  * example: `'(p21022 >= 50) AND (p31 = 0)'`\n",
     "  \n",
     "\n",
     "* a Python expression, built using Python object fields (e.g. `df.p31`) and Python operators (e.g. `==`, `!`, `|`, `&`)\n",
@@ -367,7 +403,7 @@
    "outputs": [],
    "source": [
     "# Using SQL syntax\n",
-    "df.filter(\"(p21022 >= 50) AND (p31 = 0)\").count()"
+    "df.filter('(p21022 >= 50) AND (p31 = 0)').count()"
    ]
   },
   {
@@ -402,7 +438,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "participant[\"p31\"].coding"
+    "participant['p31'].coding"
    ]
   },
   {
@@ -411,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "participant[\"p31\"].coding.codes"
+    "participant['p31'].coding.codes"
    ]
   },
   {
@@ -430,7 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "field_codes_by_keyword(\"p31\", \"female\")"
+    "field_codes_by_keyword('p31', 'female')"
    ]
   },
   {
@@ -439,7 +475,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "field_codes_by_keyword(\"p41202\", \"obesity\")"
+    "field_codes_by_keyword('p41202', 'obesity')"
    ]
   },
   {
@@ -456,7 +492,7 @@
    "outputs": [],
    "source": [
     "# Get link to UKB documentation page\n",
-    "participant[\"p31\"].linkout"
+    "participant['p31'].linkout"
    ]
   },
   {
@@ -466,7 +502,7 @@
    "outputs": [],
    "source": [
     "# Get field units\n",
-    "participant[\"p21022\"].units"
+    "participant['p21022'].units"
    ]
   },
   {
@@ -526,7 +562,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -540,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.9.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Following example added: `Obtain field name for all instances and arrays for each field_id`